### PR TITLE
Refactored deprecated constructors for Integer, Float, Double, and Long

### DIFF
--- a/Microcosm/Root/src/ec3/E/tools/ecomp/classfile.eext
+++ b/Microcosm/Root/src/ec3/E/tools/ecomp/classfile.eext
@@ -475,16 +475,16 @@ class ClassFile implements Constants {
                                     readExternal(getChar(index + 3)));
                 break;
             case CONSTANT_Integer:
-                poolObj[i] = new Integer(getInt(index + 1));
+                poolObj[i] = Integer.valueOf(getInt(index + 1));
                 break;
             case CONSTANT_Float:
-                poolObj[i] = new Float(getFloat(index + 1));
+                poolObj[i] = Float.valueOf(getFloat(index + 1));
                 break;
             case CONSTANT_Long:
-                poolObj[i] = new Long(getLong(index + 1));
+                poolObj[i] = Long.valueOf(getLong(index + 1));
                 break;
             case CONSTANT_Double:
-                poolObj[i] = new Double(getDouble(index + 1));
+                poolObj[i] = Double.valueOf(getDouble(index + 1));
                 break;
             default:
                 throw new CompilerError("bad constant pool tag: " + tag);

--- a/Microcosm/Root/src/ec3/E/tools/ecomp/constfold.eext
+++ b/Microcosm/Root/src/ec3/E/tools/ecomp/constfold.eext
@@ -35,128 +35,128 @@ class ConstantFolder implements /*imports*/ Constants {
             } else if (opcode == if_acmpeq) {
                 return 
                     new ImmediateItem(
-                        new Integer(left.value == right.value ? 1 : 0));
+                        Integer.valueOf(left.value == right.value ? 1 : 0));
             } else if (opcode == if_acmpne) {
                 return 
                     new ImmediateItem(
-                        new Integer(left.value != right.value ? 1 : 0));
+                        Integer.valueOf(left.value != right.value ? 1 : 0));
             } else {
                 Number l = (Number)left.value;
                 Number r = (Number)right.value;
                 Number res;
                 switch (opcode) {
                 case iadd:
-                    res = new Integer(l.intValue() + r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() + r.intValue()); break;
                 case isub:
-                    res = new Integer(l.intValue() - r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() - r.intValue()); break;
                 case imul:
-                    res = new Integer(l.intValue() * r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() * r.intValue()); break;
                 case idiv:
-                    res = new Integer(l.intValue() / r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() / r.intValue()); break;
                 case imod:
-                    res = new Integer(l.intValue() % r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() % r.intValue()); break;
                 case iand:
                 case bool_and:
-                    res = new Integer(l.intValue() & r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() & r.intValue()); break;
                 case ior:
                 case bool_or:
-                    res = new Integer(l.intValue() | r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() | r.intValue()); break;
                 case ixor:
-                    res = new Integer(l.intValue() ^ r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() ^ r.intValue()); break;
                 case ishl:
-                    res = new Integer(l.intValue() << r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() << r.intValue()); break;
                 case ishr:
-                    res = new Integer(l.intValue() >> r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() >> r.intValue()); break;
                 case iushr:
-                    res = new Integer(l.intValue() >>> r.intValue()); break;
+                    res = Integer.valueOf(l.intValue() >>> r.intValue()); break;
                 case if_icmpeq:
-                    res = new Integer(b2i(l.intValue() == r.intValue())); break;
+                    res = Integer.valueOf(b2i(l.intValue() == r.intValue())); break;
                 case if_icmpne:
-                    res = new Integer(b2i(l.intValue() != r.intValue())); break;
+                    res = Integer.valueOf(b2i(l.intValue() != r.intValue())); break;
                 case if_icmplt:
-                    res = new Integer(b2i(l.intValue() < r.intValue())); break;
+                    res = Integer.valueOf(b2i(l.intValue() < r.intValue())); break;
                 case if_icmpgt:
-                    res = new Integer(b2i(l.intValue() > r.intValue())); break;
+                    res = Integer.valueOf(b2i(l.intValue() > r.intValue())); break;
                 case if_icmple:
-                    res = new Integer(b2i(l.intValue() <= r.intValue())); break;
+                    res = Integer.valueOf(b2i(l.intValue() <= r.intValue())); break;
                 case if_icmpge:
-                    res = new Integer(b2i(l.intValue() >= r.intValue())); break;
+                    res = Integer.valueOf(b2i(l.intValue() >= r.intValue())); break;
 
                 case ladd:
-                    res = new Long(l.longValue() + r.longValue()); break;
+                    res = Long.valueOf(l.longValue() + r.longValue()); break;
                 case lsub:
-                    res = new Long(l.longValue() - r.longValue()); break;
+                    res = Long.valueOf(l.longValue() - r.longValue()); break;
                 case lmul:
-                    res = new Long(l.longValue() * r.longValue()); break;
+                    res = Long.valueOf(l.longValue() * r.longValue()); break;
                 case ldiv:
-                    res = new Long(l.longValue() / r.longValue()); break;
+                    res = Long.valueOf(l.longValue() / r.longValue()); break;
                 case lmod:
-                    res = new Long(l.longValue() % r.longValue()); break;
+                    res = Long.valueOf(l.longValue() % r.longValue()); break;
                 case land:
-                    res = new Long(l.longValue() & r.longValue()); break;
+                    res = Long.valueOf(l.longValue() & r.longValue()); break;
                 case lor:
-                    res = new Long(l.longValue() | r.longValue()); break;
+                    res = Long.valueOf(l.longValue() | r.longValue()); break;
                 case lxor:
-                    res = new Long(l.longValue() ^ r.longValue()); break;
+                    res = Long.valueOf(l.longValue() ^ r.longValue()); break;
                 case lshl:
-                    res = new Long(l.longValue() << r.intValue()); break;
+                    res = Long.valueOf(l.longValue() << r.intValue()); break;
                 case lshr:
-                    res = new Long(l.longValue() >> r.intValue()); break;
+                    res = Long.valueOf(l.longValue() >> r.intValue()); break;
                 case lushr:
-                    res = new Long(l.longValue() >>> r.intValue()); break;
+                    res = Long.valueOf(l.longValue() >>> r.intValue()); break;
                 case lcmp:
                     if (l.longValue() < r.longValue()) 
-                        res = new Integer(-1);
+                        res = Integer.valueOf(-1);
                     else if (l.longValue() > r.longValue()) 
-                        res = new Integer(1);
+                        res = Integer.valueOf(1);
                     else
-                        res = new Integer(0);
+                        res = Integer.valueOf(0);
                     break;
 
                 case fadd:
-                    res = new Float(l.floatValue() + r.floatValue()); break;
+                    res = Float .valueOf(l.floatValue() + r.floatValue()); break;
                 case fsub:
-                    res = new Float(l.floatValue() - r.floatValue()); break;
+                    res = Float .valueOf(l.floatValue() - r.floatValue()); break;
                 case fmul:
-                    res = new Float(l.floatValue() * r.floatValue()); break;
+                    res = Float .valueOf(l.floatValue() * r.floatValue()); break;
                 case fdiv:
-                    res = new Float(l.floatValue() / r.floatValue()); break;
+                    res = Float .valueOf(l.floatValue() / r.floatValue()); break;
                 case fmod:
-                    res = new Float(l.floatValue() % r.floatValue()); break;
+                    res = Float .valueOf(l.floatValue() % r.floatValue()); break;
                 case fcmpg: case fcmpl:
                     if (l.floatValue() < r.floatValue()) 
-                        res = new Integer(-1);
+                        res = Integer.valueOf(-1);
                     else if (l.floatValue() > r.floatValue()) 
-                        res = new Integer(1);
+                        res = Integer.valueOf(1);
                     else if (l.floatValue() == r.floatValue())
-                        res = new Integer(0);
+                        res = Integer.valueOf(0);
                     else if (opcode == fcmpg)
-                        res = new Integer(1);
+                        res = Integer.valueOf(1);
                     else
-                        res = new Integer(-1);
+                        res = Integer.valueOf(-1);
                     break;
 
                 case dadd:
-                    res = new Double(l.doubleValue() + r.doubleValue()); break;
+                    res = Double.valueOf(l.doubleValue() + r.doubleValue()); break;
                 case dsub:
-                    res = new Double(l.doubleValue() - r.doubleValue()); break;
+                    res = Double.valueOf(l.doubleValue() - r.doubleValue()); break;
                 case dmul:
-                    res = new Double(l.doubleValue() * r.doubleValue()); break;
+                    res = Double.valueOf(l.doubleValue() * r.doubleValue()); break;
                 case ddiv:
-                    res = new Double(l.doubleValue() / r.doubleValue()); break;
+                    res = Double.valueOf(l.doubleValue() / r.doubleValue()); break;
                 case dmod:
-                    res = new Double(l.doubleValue() % r.doubleValue()); break;
+                    res = Double.valueOf(l.doubleValue() % r.doubleValue()); break;
                 case dcmpg: case dcmpl:
                     if (l.doubleValue() < r.doubleValue()) 
-                        res = new Integer(-1);
+                        res = Integer.valueOf(-1);
                     else if (l.doubleValue() > r.doubleValue()) 
-                        res = new Integer(1);
+                        res = Integer.valueOf(1);
                     else if (l.doubleValue() == r.doubleValue())
-                        res = new Integer(0);
+                        res = Integer.valueOf(0);
                     else if (opcode == dcmpg)
-                        res = new Integer(1);
+                        res = Integer.valueOf(1);
                     else
-                        res = new Integer(-1);
+                        res = Integer.valueOf(-1);
                     break;
                 default:
                     throw new CompilerError("fold " + opcode);
@@ -179,34 +179,34 @@ class ConstantFolder implements /*imports*/ Constants {
             case nop:
                 res = x; break;
             case ineg:
-                res = new Integer(-x.intValue()); break;
+                res = Integer.valueOf(-x.intValue()); break;
             case ixor:
-                res = new Integer(~x.intValue()); break;
+                res = Integer.valueOf(~x.intValue()); break;
             case bool_not:
-                res = new Integer(~x.intValue() & 1); break;
+                res = Integer.valueOf(~x.intValue() & 1); break;
             case ifeq:
-                res = new Integer(b2i(x.intValue() == 0)); break;
+                res = Integer.valueOf(b2i(x.intValue() == 0)); break;
             case ifne:
-                res = new Integer(b2i(x.intValue() != 0)); break;
+                res = Integer.valueOf(b2i(x.intValue() != 0)); break;
             case iflt:
-                res = new Integer(b2i(x.intValue() < 0)); break;
+                res = Integer.valueOf(b2i(x.intValue() < 0)); break;
             case ifgt:
-                res = new Integer(b2i(x.intValue() > 0)); break;
+                res = Integer.valueOf(b2i(x.intValue() > 0)); break;
             case ifle:
-                res = new Integer(b2i(x.intValue() <= 0)); break;
+                res = Integer.valueOf(b2i(x.intValue() <= 0)); break;
             case ifge:
-                res = new Integer(b2i(x.intValue() >= 0)); break;
+                res = Integer.valueOf(b2i(x.intValue() >= 0)); break;
 
             case lneg:
-                res = new Long(-x.longValue()); break;
+                res = Long.valueOf(-x.longValue()); break;
             case lxor:
-                res = new Long(~x.longValue()); break;
+                res = Long.valueOf(~x.longValue()); break;
 
             case fneg:
-                res = new Float(-x.floatValue()); break;
+                res = Float .valueOf(-x.floatValue()); break;
 
             case dneg:
-                res = new Double(-x.doubleValue()); break;
+                res = Double.valueOf(-x.doubleValue()); break;
 
             default:
                 throw new CompilerError("fold " + opcode);

--- a/Microcosm/Root/src/ec3/E/tools/ecomp/e2j.eext
+++ b/Microcosm/Root/src/ec3/E/tools/ecomp/e2j.eext
@@ -400,7 +400,7 @@ class E2j implements /*imports*/ Constants {
         eFunDef efd = (eFunDef)stmts[i];
         if (((efd.mods & EMETHOD) != 0) && (efd.sealer.owner == tobj)) {
           ASTS params = new ASTS();
-          params.append(new Literal(pos, INTLIT, new Integer(sno)));
+          params.append(new Literal(pos, INTLIT, Integer.valueOf(sno)));
           FunObj efdfo = (FunObj)(efd.obj);
           params.append(new Literal(pos, STRINGLIT,
                                     Name.fromString(efdfo.toSignature())));
@@ -530,7 +530,7 @@ class E2j implements /*imports*/ Constants {
               AST eobj = new Subscript(pos,
                                        new Ident(pos, argsS),
                                        new Literal(pos, INTLIT,
-                                                   new Integer(j)));
+                                                   Integer.valueOf(j)));
               if (   (dcltyp.typ != null)
                   && (   (dcltyp.typ.subtype(ePredef.EobjectTyp))
                       || (dcltyp.typ.subtype(ePredef.E$interfaceTyp)))) {
@@ -573,7 +573,7 @@ class E2j implements /*imports*/ Constants {
             casebody.append(new Block(pos, caseblock));
             casebody.append(new Break(pos, null));
             cases.append(new Case(pos, new Literal(pos, INTLIT,
-                                                   new Integer(sno)),
+                                                   Integer.valueOf(sno)),
                                   casebody));
             sno++; 
           }
@@ -1217,7 +1217,7 @@ class E2j implements /*imports*/ Constants {
         new New(w.pos, 
                 new Apply(w.pos, new Ident(w.pos, BitVecS),
                           new ASTS(new Literal(w.pos, INTLIT,
-                                               new Integer(w.withobj.length)))));
+                                               Integer.valueOf(w.withobj.length)))));
       VarDef bv = new VarDef(w.pos, bitsname, 0, bitsTyp, setthem);
       // bv.print();
       newstmts.append(bv);
@@ -1326,7 +1326,7 @@ class E2j implements /*imports*/ Constants {
                                                           bitsname), 
                                                clrBitS),
                                    new ASTS(new Literal(w.pos, INTLIT,
-                                                         new Integer(i)))));
+                                                         Integer.valueOf(i)))));
             newelsepart.append(bitexcl);
 
             // if bitvector.is_empty()

--- a/Microcosm/Root/src/ec3/E/tools/ecomp/eparser.eext
+++ b/Microcosm/Root/src/ec3/E/tools/ecomp/eparser.eext
@@ -424,27 +424,27 @@ class Parser implements /* imports */ Constants {
                 break;
             case CharLit: 
                 t = new Literal(S.pos, CHARLIT,        
-                                new Integer((int)S.intVal));
+                                Integer.valueOf((int)S.intVal));
                 S.nextsym(); 
                 break;
             case IntLit:
                 if (Integer.MIN_VALUE <= S.intVal && 
                     S.intVal <= Integer.MAX_VALUE)
-                    t = new Literal(S.pos, INTLIT, new Integer((int)S.intVal));
+                    t = new Literal(S.pos, INTLIT, Integer.valueOf((int)S.intVal));
                 else
-                    t = new Literal(S.pos, LONGLIT, new Long(S.intVal));
+                    t = new Literal(S.pos, LONGLIT, Long.valueOf(S.intVal));
                 S.nextsym(); 
                 break;
             case LongLit:
-                t = new Literal(S.pos, LONGLIT,        new Long(S.intVal));
+                t = new Literal(S.pos, LONGLIT,        Long.valueOf(S.intVal));
                 S.nextsym(); 
                 break;
             case FloatLit: 
-                t = new Literal(S.pos, FLOATLIT, new Float((float)S.floatVal));
+                t = new Literal(S.pos, FLOATLIT, Float .valueOf((float)S.floatVal));
                 S.nextsym(); 
                 break;
             case DoubleLit:
-                t = new Literal(S.pos, DOUBLELIT, new Double(S.floatVal));
+                t = new Literal(S.pos, DOUBLELIT, Double.valueOf(S.floatVal));
                 S.nextsym(); 
                 break;
             case NullSy:
@@ -1796,19 +1796,19 @@ class Parser implements /* imports */ Constants {
             switch (od.tag) {
             case INTLIT:
                 ((Literal)od).val = 
-                    new Integer(-((Integer)((Literal)od).val).intValue());
+                    Integer.valueOf(-((Integer)((Literal)od).val).intValue());
                 return od;
             case LONGLIT:
                 ((Literal)od).val = 
-                    new Long(-((Long)((Literal)od).val).longValue());
+                    Long.valueOf(-((Long)((Literal)od).val).longValue());
                 return od;
             case FLOATLIT:
                 ((Literal)od).val = 
-                    new Float(-((Float)((Literal)od).val).floatValue());
+                    Float .valueOf(-((Float)((Literal)od).val).floatValue());
                 return od;
             case DOUBLELIT:
                 ((Literal)od).val = 
-                    new Double(-((Double)((Literal)od).val).doubleValue());
+                    Double.valueOf(-((Double)((Literal)od).val).doubleValue());
                 return od;
             default:
                 op = NEG;

--- a/Microcosm/Root/src/ec3/E/tools/ecomp/items.eext
+++ b/Microcosm/Root/src/ec3/E/tools/ecomp/items.eext
@@ -390,21 +390,21 @@ class ImmediateItem extends Item {
             Number n = (Number)value;
             switch (rtc) {
             case INTcode: 
-                n = new Integer(n.intValue()); break;
+                n = Integer.valueOf(n.intValue()); break;
             case LONGcode: 
-                n = new Long(n.longValue()); break;
+                n = Long.valueOf(n.longValue()); break;
             case FLOATcode: 
-                n = new Float(n.floatValue()); break;
+                n = Float.valueOf(n.floatValue()); break;
             case DOUBLEcode: 
-                n = new Double(n.doubleValue()); break;
+                n = Double.valueOf(n.doubleValue()); break;
             case OBJECTcode: 
                 throw new CompilerError("coerce");
             case BYTEcode: 
-                n = new Integer((byte)n.intValue()); break;
+                n = Integer.valueOf((byte)n.intValue()); break;
             case CHARcode: 
-                n = new Integer((char)n.intValue()); break;
+                n = Integer.valueOf((char)n.intValue()); break;
             case SHORTcode: 
-                n = new Integer((short)n.intValue()); break;
+                n = Integer.valueOf((short)n.intValue()); break;
             }
             return new ImmediateItem(n);
         }
@@ -413,7 +413,7 @@ class ImmediateItem extends Item {
 /** utility routine -- load an integer constant:
  */
     static void loadIntConst(int n) {        
-        (new ImmediateItem(new Integer(n))).load(Typ.intTyp);
+        (new ImmediateItem(Integer.valueOf(n))).load(Typ.intTyp);
     }
 }
 

--- a/Microcosm/Root/src/ec3/E/tools/ecomp/predef.eext
+++ b/Microcosm/Root/src/ec3/E/tools/ecomp/predef.eext
@@ -161,8 +161,8 @@ class Predef implements /*imports*/ Constants {
         arrayClass.scope.enter(lengthVar);
 
         enterConstant("null", Basic.nullValue, Typ.nullTyp);
-        enterConstant("true", new Integer(1), Typ.booleanTyp);
-        enterConstant("false", new Integer(0), Typ.booleanTyp);
+        enterConstant("true", Integer.valueOf(1), Typ.booleanTyp);
+        enterConstant("false", Integer.valueOf(0), Typ.booleanTyp);
         
         enterUnop("+", Typ.intTyp, Typ.intTyp, nop);
         enterUnop("+", Typ.longTyp, Typ.longTyp, nop);

--- a/Microcosm/Root/src/ec3/E/tools/ecomp/simplify.eext
+++ b/Microcosm/Root/src/ec3/E/tools/ecomp/simplify.eext
@@ -313,7 +313,7 @@ class Simplify implements /*imports*/ Constants {
                     new Subscript(
                         pos,
                         new Ident(pos, allargsS),
-                        new Literal(pos, INTLIT, new Integer(j))),
+                        new Literal(pos, INTLIT, Integer.valueOf(j))),
                     vtyp));
         }
 
@@ -341,7 +341,7 @@ class Simplify implements /*imports*/ Constants {
         return
             new Case(
                 pos,
-                new Literal(pos, INTLIT, new Integer(tag)),
+                new Literal(pos, INTLIT, Integer.valueOf(tag)),
                 casestats);
     }
 
@@ -425,7 +425,7 @@ class Simplify implements /*imports*/ Constants {
                                 new Subscript(pos, 
                                               new Ident(pos, labelsS),
                                               new Literal(pos, INTLIT,
-                                                          new Integer(i))),
+                                                          Integer.valueOf(i))),
                                 new Literal(pos, STRINGLIT, sig)));
         stats.append(asgn);
       }
@@ -524,7 +524,7 @@ class Simplify implements /*imports*/ Constants {
                 new New(pos, 
                         new Subscript(pos, toAST(pos, Predef.stringTyp), 
                                       new Literal(pos, INTLIT,
-                                          new Integer(cd.closures.length))))),
+                                          Integer.valueOf(cd.closures.length))))),
             makeClosureLabels(cd),
             new VarDef(
                 pos, labelS, PRIVATE,
@@ -625,7 +625,7 @@ class Simplify implements /*imports*/ Constants {
                     new ASTS(
                         new Aggregate(pos, newargs),
                         receiver,
-                        new Literal(pos, INTLIT, new Integer(closnum)))));
+                        new Literal(pos, INTLIT, Integer.valueOf(closnum)))));
     }
 
 
@@ -681,7 +681,7 @@ class Simplify implements /*imports*/ Constants {
             return 
                 new Subscript(
                     t.pos, t, 
-                    new Literal(t.pos, INTLIT, new Integer(0)));
+                    new Literal(t.pos, INTLIT, Integer.valueOf(0)));
         else
             return t;
     }
@@ -915,7 +915,7 @@ class Simplify implements /*imports*/ Constants {
                             t.dcltyp,
                             new Literal(
                                 pos, INTLIT, 
-                                new Integer(1))));
+                                Integer.valueOf(1))));
             t.dcltyp = annot(
                 new Subscript(t.dcltyp.pos, strip(t.dcltyp), null), 
                 new ArrayTyp(t.obj.typ));


### PR DESCRIPTION
Rolling back the "fix" that changed "new [Integer|Float|Double|Long]" to "[IntegerFloat|Double|Long].valueOf" since that method does NOT EXIST in 1.1 Java (the current compile target". I did reverted as a branch in order to save the work in case we updated to use a Java version greater than 1.1
